### PR TITLE
Stop writing out mouse position messages into logs

### DIFF
--- a/src/waybar.cpp
+++ b/src/waybar.cpp
@@ -104,9 +104,8 @@ auto Waybar::hideAllMonitors() const -> void {
         auto [root_x, root_y] = Hyprland::getCursorPos();
 
 	// show mouse position only if it runs in terminal -> eg. stop trashing all the log files
-	if (isConsole) {
+	if (isConsole)
         	Utils::log(Utils::LOG, "Mouse at position ({},{})\n", root_x, root_y);
-	}
         // show waybar
         if (!open && root_y < 5) {
             Utils::log(Utils::INFO, "Opening it. \n");


### PR DESCRIPTION
Due to the nature of the code as of now:
- its polling mouse, 
- and say something about it on stdout _and_ into logs

```
sudo grep 'Found mouse' /var/log/syslog | wc -l
3867491
```

This PR fixes the ~4 million times of log writes. Only show the mouse messages if one runs autowaybar in a terminal (tty).
Also "standardizes" the mouse messages. 
By the way, what do you feel renaming the repo from 'auto-waybar-cpp' to 'autowaybar'?

Long story:
Of course, the more elegant way is have a debug log level with a switch/start parameter attached to it -> so one can intentionally send out a lot of into into logs too. Until that time comes this helps. :)