### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ xmake install --admin
 bind=$mainMod, W, exec, if ! pgrep waybar; then waybar & else killall -SIGUSR2 waybar & fi
 #autohide with autowaybar
 bind=$mainMod, A, exec, if ! pgrep autowaybar; then autowaybar -m all & fi
-bind=$mainMod SHIFT, A, exec, killall -9 autowaybar
+bind=$mainMod SHIFT, A, exec, killall -SIGTERM autowaybar
 ```
 ### Know your monitors and their names for multi-monitor
 ```bash


### PR DESCRIPTION
Fix sample binds' for hyprland.conf by replacing `killall -9` to `killall -SIGTERM` . Therefore the signal handling work as intended in autowaybar -> waybar restarted upon close of autwaybar.