### PR TITLE
Support for vertical stacked monitor layouts

### DIFF
--- a/src/Hyprland.cpp
+++ b/src/Hyprland.cpp
@@ -41,6 +41,10 @@ namespace Hyprland {
                 temp.x_coord = data[i]["x"].asInt();
             }
 
+            if (!data[i]["y"].empty()) {
+                temp.y_coord = data[i]["y"].asInt();
+            }
+
             float scale = 1.0f;
             if (!data[i]["scale"].empty()) {
                scale = data[i]["scale"].asFloat();
@@ -51,7 +55,12 @@ namespace Hyprland {
                 temp.width = data[i]["width"].asInt() / scale;
             }
 
-            Utils::log(Utils::LogLevel::LOG, "Monitor named {} found in x: {}, width: {}. \n", temp.name, temp.x_coord, temp.width);
+            // calculate width taking into account scaling factor
+            if (!data[i]["height"].empty()) {
+                temp.height = data[i]["height"].asInt() / scale;
+            }
+
+            Utils::log(Utils::LogLevel::LOG, "Monitor named {} found in x: {}, y: {}, width: {}. \n", temp.name, temp.x_coord, temp.y_coord, temp.width, temp.height);
             monitors.push_back(temp);
         }
 

--- a/src/waybar.cpp
+++ b/src/waybar.cpp
@@ -123,20 +123,20 @@ auto Waybar::hideCustom() -> void {
     // main loop
     while (!g_interruptRequest) {
         bool need_reload {false}; // this is false, until otherwise
-        const bool in_target_mon = mon.x_coord < mouse_x &&
-            mon.x_coord + mon.width > mouse_x;
-        
+        const bool in_target_mon = mon.x_coord <= mouse_x && mon.x_coord + mon.width >= mouse_x && mon.y_coord <= mouse_y && mon.y_coord + mon.height >= mouse_y;
+        const int local_bar_threshold = mon.y_coord + m_bar_threshold;
+
         // if target monitor shown
         if (in_target_mon && !mon.hidden) {
             // outside of the threshold -> hide it 
-            if (mouse_y > m_bar_threshold) {
+            if (mouse_y > local_bar_threshold) {
                 Utils::log(Utils::INFO, "Mon: {} needs to be hidden.\n", mon.name);
                 mon.hidden = true;
                 need_reload = true;
             } 
             // inside the threshold -> keep showing
-            else if (mouse_y <= m_bar_threshold) {
-                while (!g_interruptRequest && mouse_y <= m_bar_threshold) {
+            else if (mouse_y <= local_bar_threshold) {
+                while (!g_interruptRequest && mouse_y <= local_bar_threshold) {
                     std::this_thread::sleep_for(80ms);
                     std::tie(mouse_x, mouse_y) = Hyprland::getCursorPos();
                 }
@@ -146,8 +146,8 @@ auto Waybar::hideCustom() -> void {
                 need_reload = true;
             }
         } 
-        // if we touch top -> show it 
-        else if (in_target_mon && mon.hidden && mouse_y < 5) {
+        // if we touch top of the monitor -> show it 
+        else if (in_target_mon && mon.hidden && mouse_y < mon.y_coord + 7) {
             Utils::log(Utils::INFO, "Mon: {} needs to be shown.\n", mon.name);
             mon.hidden = false;
             need_reload = true;
@@ -191,26 +191,31 @@ auto Waybar::hideAllMonitors(bool is_visible) const -> void {
         if (m_is_console && m_is_verbose)
             Utils::log(Utils::LOG, "Mouse at position ({},{})\n", root_x, root_y);
 
-        // show waybar
-        if (!is_visible && root_y < 5) {
-            Utils::log(Utils::INFO, "Opening it. \n");
-            kill(m_waybar_pid, SIGUSR1);
-            is_visible= true;
+        for (auto &mon : m_outputs) {
+            // show waybar
+            if (!is_visible && mon.y_coord <= root_y && root_y < mon.y_coord + 7)
+            {
+                Utils::log(Utils::INFO, "Opening it. \n");
+                kill(m_waybar_pid, SIGUSR1);
+                is_visible = true;
 
-            auto temp = Hyprland::getCursorPos();
+                auto temp = Hyprland::getCursorPos();
 
-            // keep it open
-            while (temp.second < m_bar_threshold && !g_interruptRequest) {
-                std::this_thread::sleep_for(80ms);
-                temp = Hyprland::getCursorPos();
+                // keep it open
+                while (temp.second < m_bar_threshold && !g_interruptRequest)
+                {
+                    std::this_thread::sleep_for(80ms);
+                    temp = Hyprland::getCursorPos();
+                }
             }
+            // closing waybar
+            else if (is_visible && root_y < mon.y_coord + mon.height && root_y > mon.y_coord + m_bar_threshold)
+            {
+                Utils::log(Utils::INFO, "Hiding it. \n");
+                kill(m_waybar_pid, SIGUSR1);
+                is_visible = false;
 
-        }
-        // closing waybar
-        else if (is_visible && root_y > m_bar_threshold) {
-            Utils::log(Utils::INFO, "Hiding it. \n");
-            kill(m_waybar_pid, SIGUSR1);
-            is_visible = false;
+            }
         }
 
         std::this_thread::sleep_for(80ms);
@@ -256,19 +261,20 @@ auto Waybar::hideFocused() -> void {
         bool need_reload {false}; // this is false, until otherwise
 
         for (auto& mon : m_outputs) {
-            const bool in_current_mon = mon.x_coord < mouse_x && mon.x_coord + mon.width > mouse_x;
+            const bool in_current_mon = mon.x_coord <= mouse_x && mon.x_coord + mon.width >= mouse_x && mon.y_coord <= mouse_y && mon.y_coord + mon.height >= mouse_y;
+            const int local_bar_threshold = mon.y_coord + m_bar_threshold;
 
             // if current monitor shown
             if (in_current_mon && !mon.hidden) {
                 // outside of the threshold -> hide it 
-                if (mouse_y > m_bar_threshold) {
+                if (mouse_y > local_bar_threshold) {
                     Utils::log(Utils::INFO, "Mon: {} needs to be hidden.\n", mon.name);
                     mon.hidden = true;
                     need_reload = true;
                 } 
                 // inside the threshold -> keep showing
-                else if (mouse_y <= m_bar_threshold) {
-                    while (!g_interruptRequest && mouse_y <= m_bar_threshold) {
+                else if (mouse_y <= local_bar_threshold) {
+                    while (!g_interruptRequest && mouse_y <= local_bar_threshold) {
                         std::this_thread::sleep_for(80ms);
                         std::tie(mouse_x, mouse_y) = Hyprland::getCursorPos();
                     }
@@ -279,13 +285,13 @@ auto Waybar::hideFocused() -> void {
                 }
             } 
             // if we touch top -> show it 
-            else if (in_current_mon && mon.hidden && mouse_y < 5) {
+            else if (in_current_mon && mon.hidden && mouse_y < mon.y_coord + 7) {
                 Utils::log(Utils::INFO, "Mon: {} needs to be shown.\n", mon.name);
                 mon.hidden = false;
                 need_reload = true;
             }
-            // if left/right hidden -> show it
-            else if ((mon.x_coord + mon.width < mouse_x || mon.x_coord > mouse_x) && mon.hidden) {
+            // if left/right and top/bottom hidden -> show it
+            else if (((mon.x_coord + mon.width < mouse_x || mon.x_coord > mouse_x) || (mon.y_coord + mon.height < mouse_y || mon.y_coord > mouse_y)) && mon.hidden) {
                 Utils::log(Utils::INFO, "Mon: {} needs to be shown.\n", mon.name);
                 mon.hidden = false;
                 need_reload = true;

--- a/src/waybar.cpp
+++ b/src/waybar.cpp
@@ -192,6 +192,8 @@ auto Waybar::hideAllMonitors(bool is_visible) const -> void {
             Utils::log(Utils::LOG, "Mouse at position ({},{})\n", root_x, root_y);
 
         for (auto &mon : m_outputs) {
+            const int local_bar_threshold = mon.y_coord + m_bar_threshold;
+            
             // show waybar
             if (!is_visible && mon.y_coord <= root_y && root_y < mon.y_coord + 7)
             {
@@ -202,14 +204,14 @@ auto Waybar::hideAllMonitors(bool is_visible) const -> void {
                 auto temp = Hyprland::getCursorPos();
 
                 // keep it open
-                while (temp.second < m_bar_threshold && !g_interruptRequest)
+                while (temp.second < local_bar_threshold && !g_interruptRequest)
                 {
                     std::this_thread::sleep_for(80ms);
                     temp = Hyprland::getCursorPos();
                 }
             }
             // closing waybar
-            else if (is_visible && root_y < mon.y_coord + mon.height && root_y > mon.y_coord + m_bar_threshold)
+            else if (is_visible && root_y < mon.y_coord + mon.height && root_y > local_bar_threshold)
             {
                 Utils::log(Utils::INFO, "Hiding it. \n");
                 kill(m_waybar_pid, SIGUSR1);

--- a/src/waybar.hpp
+++ b/src/waybar.hpp
@@ -14,15 +14,15 @@ static bool g_interruptRequest = false;
 // TYPES
 struct monitor_info_t {
     std::string name{};
-    int x_coord{}, width{};
+    int x_coord{}, y_coord{}, width{}, height{};
     bool hidden = false;
 
     bool operator<(const monitor_info_t& other) const {
-        return x_coord < other.x_coord;
+        return x_coord < other.x_coord && y_coord < other.y_coord;
     }
 
     bool operator==(const monitor_info_t& other) const {
-        return name == other.name && x_coord == other.x_coord;
+        return name == other.name && x_coord == other.x_coord && y_coord == other.y_coord;
     }
 };
 


### PR DESCRIPTION
Thanks for creating this, I really needed a more efficient way of doing this than my previous slow bash script. 

It didn't quite work for my setup since I use a vertical stacked layout with a large 32:9 monitor as my primary with a 16:9 monitor on top. The bar would only appear when the top monitor would be hovered since all three, `Waybar::hideAllMonitors`, `Waybar::hideCustom`, and `Waybar::hideFocused` methods only check the if the cursor y position is between 0 and 5 which means all monitors must be the same y position to work properly.

I've resolved this now by replacing the absolute cursor y position with a per monitor value and enclosing the monitor into a box rather than just a range of x values. This now fully works with my current monitor layout and also worked with a few different vertical configurations that I tried.

I am pretty inexperienced with C++ so I wrote the best of what I could. Let me know if anything should be changed!
